### PR TITLE
Add AES-GCM support from RFC5084

### DIFF
--- a/asn1crypto/algos.py
+++ b/asn1crypto/algos.py
@@ -632,6 +632,15 @@ class CcmParams(Sequence):
     ]
 
 
+class GcmParams(Sequence):
+    # https://tools.ietf.org/html/rfc5084
+    # aes_ICVlen: 4 | 8 | 12 | 13 | 14 | 15 | 16
+    _fields = [
+        ('aes_nonce', OctetString),
+        ('aes_icvlen', Integer, {'optional': True}),
+    ]
+
+
 class PSourceAlgorithmId(ObjectIdentifier):
     _map = {
         '1.2.840.113549.1.1.9': 'p_specified',
@@ -811,6 +820,10 @@ class EncryptionAlgorithm(_ForceNullParameters, Sequence):
         'aes128_ccm': CcmParams,
         'aes192_ccm': CcmParams,
         'aes256_ccm': CcmParams,
+        'aes128_gcm': GcmParams,
+        'aes192_gcm': GcmParams,
+        'aes256_gcm': GcmParams,
+        # From PKCS#5
         # From PKCS#5
         'pbes1_md2_des': Pbes1Params,
         'pbes1_md5_des': Pbes1Params,


### PR DESCRIPTION
Fixes #2 <!-- Needed for GitHub to link the issue to the PR -->

## Add AES-GCM support from RFC5084
This commit adds support for AES-GCM (Galois/Counter Mode) as specified in RFC5084. The implementation includes:

- A new `GcmParams` class to handle GCM-specific parameters including nonce and ICV length
- Support for 128/192/256-bit AES-GCM variants in the `EncryptionAlgorithm` class

This addresses a gap in the library&#39;s encryption algorithm support by adding a widely-used authenticated encryption mode.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.pages.dev/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1YnVzZXJjb250ZW50LmNvbS9oYXJyeS1wYXRjaGVyL2FmZDUxNGIyM2MyNGM4NTk4OGE4NWQzMTgxMDczNDRiL3Jhdy9jMGY1MjYwZmI4ODdlZGY2NTI3MThkOGU3NjEwZDQ2MTA4YWUwZmYwL3N3ZWJlbmNoX3dib25kX19hc24xY3J5cHRvXzI3OF8wLmpzb24&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL2hhcnJ5LXBhdGNoZXIvYXNuMWNyeXB0by9wdWxsLzM2) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally let us know using [this form](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu) 📬.